### PR TITLE
fix(index.html): use fully qualified language identifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,12 +56,15 @@
                                     <label class="col-sm-2" for="language">UI Language</label>
                                     <div class="col-sm-10">
                                         <select class="form-control" id="language">
-                                            <option value="en">English</option>
-                                            <option value="nl">Nederlands</option>
-                                            <option value="fr">Français</option>
-                                            <option value="de">Deutsch</option>
+                                            <option value="de-de">Deutsch</option>
+                                            <option value="en-gb">English (UK)</option>
+                                            <option value="en-us">English (US)</option>
+                                            <option value="es-es">Español</option>
+                                            <option value="fr-fr">Français</option>
+                                            <option value="it-it">Italiano</option>
+                                            <option value="nl-nl">Nederlands</option>
                                         </select>
-                                        <small>Available options: <code>en, fr, nl, de</code></small>
+                                        <small>Available options: <code>de-de, en-gb, en-us, es-es, fr-fr, it-it, nl-nl</code></small>
                                     </div>
                                 </div>
                                 <div class="form-group">


### PR DESCRIPTION
Language identifiers now use the fully qualified name with `<locale>-<region>` format. With this, variants like `en-gb` can be used as well.