### PR TITLE
Fix demo page (wrong URL when including JS lib)

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
 
     <!-- Dependencies -->
 
-    <script type="text/javascript" src="http://localhost:30031/embed/spp/1.0.0/api.min.js"></script>
+    <script type="text/javascript" src="https://embed.sendcloud.sc/spp/1.0.0/api.min.js"></script>
     <!-- Usage -->
     <script type="text/javascript" id="actual-code">
       var resultElem = document.getElementById('result'),


### PR DESCRIPTION
Demo page is not working because JS file is not correctly linked.

This 1-line PR fixes this issue.